### PR TITLE
Increase the NetuitiveHandler batch size to 500

### DIFF
--- a/netuitive-agent.conf
+++ b/netuitive-agent.conf
@@ -54,7 +54,7 @@ api_key = apikey
 # tags = tag1:tag1val, tag2:tag2val
 
 # How many samples to store before sending to Netuitive
-batch = 100
+batch = 500
 
 # how many batches to store before trimming
 max_backlog_multiplier = 5
@@ -205,4 +205,3 @@ datefmt =
 # /etc/diamond/configs/net.conf
 # [collectors]
 #
-


### PR DESCRIPTION
Incremental posts are synchronous calls made during collection if the
number of samples cached is equal to the batch size. These are invasive,
heavy operations which slow down collection and use a lot of CPU. Each
collector flushes data after collection is completed, so increasing the
batch size won't affect the timeliness of data.