### PR TITLE
Fixes #16 - Updates netuitive-agent.conf to reflect upstream

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 Netuitive Docker Agent Release History
 ======================================
 
+Version next
+---------------------------
+- Update netuitive-agent.conf to be in line with upstream defaults.
+
 Version 0.2.11
 ---------------------------
 - pull linux agent 0.6.6 for various bug fixes including a slow memory leak

--- a/netuitive-agent.conf
+++ b/netuitive-agent.conf
@@ -22,6 +22,7 @@ pid_file = /opt/netuitive-agent/netuitive-agent.pid
 
 # Directory to load collector modules from
 collectors_path = /opt/netuitive-agent/collectors/
+
 # Directory to load collector configs from
 collectors_config_path = /opt/netuitive-agent/conf/collectors/
 
@@ -47,8 +48,11 @@ keys = rotated_file
 ### Netuitive URL to post the metrics
 url = https://api.app.netuitive.com/ingest/infrastructure
 
-### Netuitive Datasource api key
+### Metricly Datasource api key
 api_key = apikey
+
+### Metricly Cloud HTTP Connection Timeout
+connection_timeout = 5
 
 ### Uncomment to add tags
 # tags = tag1:tag1val, tag2:tag2val
@@ -61,6 +65,10 @@ max_backlog_multiplier = 5
 
 # Trim down how many batches
 trim_backlog_multiplier = 4
+
+# Write metric fqns to a local file.
+write_metric_fqns = False
+metric_fqns_path = /opt/netuitive-agent/log/metric_fqns.txt
 
 # local statsd server
 [[[statsd]]]
@@ -122,6 +130,9 @@ interval = 60
 splay = 1
 method = threading
 simple = True
+
+[[BaseCollector]]
+enabled = False
 
 [[CPUCollector]]
 enabled = True


### PR DESCRIPTION
Updating conf params from https://github.com/Netuitive/omnibus-netuitive-agent/blob/master/netuitive/conf/netuitive-agent.conf