### PR TITLE
Update netuitive-agent to v0.7.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV TAGS ""
 RUN  yum -y update \
   && rpm --import https://repos.app.netuitive.com/RPM-GPG-KEY-netuitive \
   && rpm -ivh https://repos.app.netuitive.com/rpm/noarch/netuitive-repo-1-0.2.noarch.rpm \
-  && yum -y install netuitive-agent-0.7.5-187.el6 \
+  && yum -y install netuitive-agent-0.7.6-188.el6 \
   && /sbin/chkconfig netuitive-agent off \
   && yum clean all \
   && find /opt/netuitive-agent/collectors/ -type f -name "*.py" -print0 | xargs -0 sed -i 's/\/proc/\/host_proc/g' \

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@ Netuitive Docker Agent Release History
 
 Version next  
 ----------------------------
+- Update netuitive-agent to v0.7.6
 
 Version 0.2.16
 ----------------------------


### PR DESCRIPTION
A new version of the netuitive-agent is available. The docker-agent should use the latest version.