### PR TITLE
Properly anchor the collector name when locating the file

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@ Netuitive Docker Agent Release History
 
 Version next
 ----------------------------
+
+Version 0.2.16
+----------------------------
 - Update netuitive-agent to v0.7.5
 - Add a default TCPCollector config
 - Add ConsulCollector.conf to project config

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,9 +6,6 @@ Version next
 
 Version 0.2.16
 ----------------------------
-
-Version 0.2.16
-----------------------------
 - Update netuitive-agent to v0.7.5
 - Add a default TCPCollector config
 - Add ConsulCollector.conf to project config

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,12 +11,7 @@ Version 0.2.17
 Version 0.2.16
 ----------------------------
 - Update netuitive-agent to v0.7.5
-- Add a default TCPCollector config
-- Add ConsulCollector.conf to project config
-- Add pkg concurrent-log-handler to fix locking, I/O errors when multiprocess logging to single file
 - Make ConcurrentRotatingFileHandler default log handler in netuitive-agent.conf
-- Add Docker Container Uptime feature to the NetuitiveDockerCollector
-- Add support for UDP to PortCheckCollector
 
 Version 0.2.15
 ----------------------------

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,7 +54,7 @@ fi
 for v in `set -o posix; set | sed 's% %:#:%g'`; do
 	if [[ "${v}" == "COLLECTOR_"*  ]]; then
 
-		FILE=`echo "${COLLECTORS}" | grep -i "$(echo "${v}" | sed 's%^COLLECTOR_%%;s%_.*%%' | tr 'A-Z' 'a-z')"`
+		FILE=`echo "${COLLECTORS}" | grep -i "^$(echo "${v}" | sed 's%^COLLECTOR_%%;s%_.*%%' | tr 'A-Z' 'a-z')$"`
 		KEY=`echo "${v}" | sed 's%=.*%%;s%__%##%g;s%.*_%%;s%##%_%g' | tr 'A-Z' 'a-z'`
 		VAL=`echo "${v}" | sed "s%.*=%%;s%[']%%g"`
 


### PR DESCRIPTION
This PR addresses an issue when trying to configure a collector with a repeated (portion) of the name, for example `Jolokia`. This would match `CassandraJolokiaCollector.conf`, `JolokiaCollector.conf`, and `KafkaJolokiaCollector.conf` and the `entrypoint.sh` fails. Same applies to `Http`.